### PR TITLE
Change MAX_IMAGE_NAME_LENGTH variable 80 to 48

### DIFF
--- a/src/spaceone/repository/service/plugin_service.py
+++ b/src/spaceone/repository/service/plugin_service.py
@@ -13,7 +13,7 @@ from spaceone.repository.manager.repository_manager import RepositoryManager
 
 _LOGGER = logging.getLogger(__name__)
 
-MAX_IMAGE_NAME_LENGTH = 80
+MAX_IMAGE_NAME_LENGTH = 48
 REGISTRY_MAP = {
     "DOCKER_HUB": "DockerHubConnector",
     "AWS_PRIVATE_ECR": "AWSPrivateECRConnector",


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
* Change MAX_IMAGE_NAME_LENGTH variable 80 to 48 because it cannot be displayed due to image limitations.